### PR TITLE
Fix handling for existing samples

### DIFF
--- a/Auxilliary_procedures/p_OXBS_namechange_step1.sql
+++ b/Auxilliary_procedures/p_OXBS_namechange_step1.sql
@@ -152,11 +152,12 @@ end
 insert into @ind_sample_pairs
 (ind_ext_name, sample_ext_name, rn)
 select i.external_name as individual_external_name, s.external_name as sample_external_name,
-ROW_NUMBER() over (partition by i.external_name order by i.external_name)
+ROW_NUMBER() over (partition by sns.sample_name_stem order by sns.sample_name_stem)
 from @tmp tt
 inner join GTDB2.dbo.tube t on t.identifier = tt.tube_name
 inner join GTDB2.dbo.tube_aliquot ta on ta.tube_id = t.tube_id
 inner join GTDB2.dbo.sample s on s.sample_id = ta.sample_id
+inner join @sample_name_stem sns on sns.sample_id = s.sample_id
 inner join GTDB2.dbo.individual i on i.individual_id = s.individual_id
 
 delete from isp

--- a/Auxilliary_procedures/p_OXBS_namechange_step2.sql
+++ b/Auxilliary_procedures/p_OXBS_namechange_step2.sql
@@ -86,6 +86,7 @@ declare @samples_staging table(
 	name_stem varchar(255)
 )
 
+-- exclude samples that are found in the existing oxbs table
 insert into @samples_staging
 (sample_name, dot_index, dot_index_reverse)
 select distinct
@@ -94,6 +95,8 @@ select distinct
 	PATINDEX("%.%", REVERSE( s.identifier ))
 from @tmp tt
 inner join GTDB2.dbo.sample s on s.identifier = tt.sample_name
+left outer join dbo.oxbs_namechange_existing_oxbs eo on eo.oxbs_sample_id = s.sample_id
+where eo.oxbs_sample_id is null
 
 update s set
 	s.name_stem = SUBSTRING( s.sample_name, 1, s.dot_index)


### PR DESCRIPTION
Step 1: populate ind-sample-pairs (to be created in sample submission
form). Match against name stem of samples associated with tubes.
Partition row number over namestem entries. Rownumber has a part when
deleting entries corresponding to existing samples.

Step 2: When adding samples to be updated, don't include samples that
are found in existing oxbs sample table.

Step 3: When finding new sample references for tubes, have separate
treatment for existing oxbs samples.

Suggested future workflow
Step1: 
Input: tube names 
Output: List samples to be created in sample submission forms. 
Step 2:
Input: tube list from previous
Output: Update sample names. Give a suggested tube-sample association
Step 3:
Input: A list of tube sample associations, given from previous step
Output: Update tube names, sample references. 