### PR TITLE
Add proc to check if id-panel markers have changed

### DIFF
--- a/Auxilliary_procedures/Auxilliary_procedures.ssmssqlproj
+++ b/Auxilliary_procedures/Auxilliary_procedures.ssmssqlproj
@@ -61,6 +61,12 @@
           <AssociatedConnUserName />
           <FullPath>p_FileToSelect_GenerateScript.sql</FullPath>
         </FileNode>
+        <FileNode Name="p_IdPanelStrandCheck.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:mm-wchs001:False:admin_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>mm-wchs001</AssociatedConnSrvName>
+          <AssociatedConnUserName>admin_edvard</AssociatedConnUserName>
+          <FullPath>p_IdPanelStrandCheck.sql</FullPath>
+        </FileNode>
         <FileNode Name="p_ListDirectory.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:True</AssociatedConnectionMoniker>
           <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
@@ -115,8 +121,8 @@
       <Items />
     </LogicalFolder>
   </Items>
-  <SccProjectName>$/TfsRoot/LIMS/Database_Objects</SccProjectName>
+  <SccProjectName />
   <SccAuxPath />
-  <SccLocalPath>..</SccLocalPath>
-  <SccProvider>MSSCCI:Team Foundation Server MSSCCI Provider</SccProvider>
+  <SccLocalPath />
+  <SccProvider />
 </SqlWorkbenchSqlProject>

--- a/Auxilliary_procedures/p_IdPanelStrandCheck.sql
+++ b/Auxilliary_procedures/p_IdPanelStrandCheck.sql
@@ -1,0 +1,36 @@
+use Auxilliary
+
+
+go
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+alter procedure p_IdPanelStrandCheck
+as
+begin
+SET NOCOUNT ON
+create table #strandrefs (
+	marker varchar(255),
+	is_top_in_plus bit
+)
+
+
+bulk insert #strandrefs from 'D:\Scripts\Proc_references\gtdb2_id_panel_check\id_panel_strand_refs.txt' 
+with (
+	fieldterminator = '\t',
+	rowterminator = '\n'
+)
+
+if exists(select *
+from #strandrefs tsf
+inner join GTDB2.dbo.marker m on m.identifier = tsf.marker
+inner join GTDB2.dbo.allele_variant_plus avp on m.marker_id = avp.marker_id
+where not tsf.is_top_in_plus = avp.is_top_in_plus)
+begin
+	RAISERROR('Some of the strand referenses for id-panel markers have changed, and need to be investigated!', 15, 1)
+end
+
+SET NOCOUNT OFF
+end

--- a/Database_Objects.ssmssln
+++ b/Database_Objects.ssmssln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# SQL Server Management Studio Solution File, Format Version 11.00
+Microsoft Visual Studio Solution File, Format Version 12.00
+# SQL Server Management Studio Solution File, Format Version 13.00
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "DBAMonitor_procedures", "DBAMonitor\DBAMonitor_procedures\DBAMonitor_procedures.ssmssqlproj", "{417A0108-9E50-427E-B228-E6152528BD34}"
 EndProject
 Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "Administration_procedures", "Administration_procedures\Administration_procedures.ssmssqlproj", "{528B9375-7771-4F90-A1B8-9A6FD043E2D0}"
@@ -10,5 +12,14 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Default|Default = Default|Default
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{417A0108-9E50-427E-B228-E6152528BD34}.Default|Default.ActiveCfg = Default
+		{528B9375-7771-4F90-A1B8-9A6FD043E2D0}.Default|Default.ActiveCfg = Default
+		{178080DB-E435-4511-A5B5-1FAFA37353C8}.Default|Default.ActiveCfg = Default
+		{90770AD1-C7F3-41A5-B30B-29B462CD734A}.Default|Default.ActiveCfg = Default
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
The check involves the marker strand references in plus. This proc is
used in a scheduled task.