### PR TITLE
Bugfix, oxbs step2, check for ord sample id in existing oxbs table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Temporary Items
 # Added by SNPSEQ
 *.vspscc
 *.vssscc
+*~

--- a/Auxilliary_procedures/p_OXBS_namechange_step2.sql
+++ b/Auxilliary_procedures/p_OXBS_namechange_step2.sql
@@ -95,7 +95,7 @@ select distinct
 	PATINDEX("%.%", REVERSE( s.identifier ))
 from @tmp tt
 inner join GTDB2.dbo.sample s on s.identifier = tt.sample_name
-left outer join dbo.oxbs_namechange_existing_oxbs eo on eo.oxbs_sample_id = s.sample_id
+left outer join dbo.oxbs_namechange_existing_oxbs eo on eo.ord_sample_id = s.sample_id
 where eo.oxbs_sample_id is null
 
 update s set


### PR DESCRIPTION
The sample name provided by user should be mapped to
oxbs_namechange_existing_oxbs.ord_sample_id, in order to exclude samples
which names should be modified. Step 2 and step 3 worked fine for the
cep samples after this change.