### PR TITLE
Fix name stem for sample in step 3

### DIFF
--- a/Auxilliary_procedures/p_OXBS_namechange_step3.sql
+++ b/Auxilliary_procedures/p_OXBS_namechange_step3.sql
@@ -112,7 +112,7 @@ insert into @sample_match
 select sample_name from oxbs_tube_sample_couple
 
 update sm
-	set dot_index_reverse = PATINDEX("%.%", reverse( sm.sample_orig_name))
+	set dot_index_reverse = PATINDEX("%.%", reverse( sm.sample_orig_name)) - 1
 from @sample_match sm
 
 update sm


### PR DESCRIPTION
Before, name step was one character short, ie. sample1-r1.v1 became
sample1-r, instead of sample1-r1. This is fixed now.