### PR TITLE
Adjust for changed file reference on server

### DIFF
--- a/Administration_procedures/p_BackupDevelLatestMerge.sql
+++ b/Administration_procedures/p_BackupDevelLatestMerge.sql
@@ -14,7 +14,7 @@ as
 begin
 SET NOCOUNT ON
 
-backup database gtdb2_devel to disk = 'D:\Scripts\Proc_references\Devel_backups\Latest merge\gtdb2_devel_backup.bak'
+backup database gtdb2_devel to disk = 'D:\Proc_references\Devel_backups\Latest merge\gtdb2_devel_backup.bak'
 with init, skip
 
 

--- a/Administration_procedures/p_BackupDevelLatestRelease.sql
+++ b/Administration_procedures/p_BackupDevelLatestRelease.sql
@@ -14,7 +14,7 @@ as
 begin
 SET NOCOUNT ON
 
-backup database gtdb2_devel to disk = 'D:\Scripts\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak'
+backup database gtdb2_devel to disk = 'D:\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak'
 with init, skip
 
 

--- a/Administration_procedures/p_CloneGTDB2DevelToPersonal.sql
+++ b/Administration_procedures/p_CloneGTDB2DevelToPersonal.sql
@@ -17,7 +17,7 @@ GO
 --				initials is 'ee', then a devel database with name GTDB2_devel_ee2 will be created. If there
 --				is an existing database with name GTDB2_devel_ee, it will not be affected. 
 
-create procedure p_CloneGTDB2DevelToPersonal @version int = null, @latest_release bit = 1, @latest_merge bit = 0
+alter procedure p_CloneGTDB2DevelToPersonal @version int = null, @latest_release bit = 1, @latest_merge bit = 0
 
 as
 begin
@@ -31,10 +31,10 @@ declare @backup_file varchar(1024)
 
 
 if @latest_merge = 1 begin
-	set @backup_file = '''D:\Scripts\Proc_references\Devel_backups\Latest merge\gtdb2_devel_backup.bak'''
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest merge\gtdb2_devel_backup.bak'''
 end
 if @latest_release = 1 begin
-	set @backup_file = '''D:\Scripts\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak'''
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak'''
 end
 
 -- Find 'personal' devel db name for current user

--- a/Administration_procedures/p_RestoreGTDB2Devel.sql
+++ b/Administration_procedures/p_RestoreGTDB2Devel.sql
@@ -27,10 +27,10 @@ declare @backup_file varchar(1024)
 set @devel_db_name = 'GTDB2_devel'
 
 if @latest_merge = 1 begin
-	set @backup_file = '''D:\Scripts\Proc_references\Devel_backups\Latest merge\gtdb2_devel_backup.bak'''
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest merge\gtdb2_devel_backup.bak'''
 end
 if @latest_release = 1 begin
-	set @backup_file = '''D:\Scripts\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak'''
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak'''
 end
 
 -- Restore backup from latest release folder

--- a/Administration_procedures/p_admin_CloneGTDB2DevelLatestRelease.sql
+++ b/Administration_procedures/p_admin_CloneGTDB2DevelLatestRelease.sql
@@ -50,7 +50,7 @@ end
 '
 
 set @sql = @sql + 
-'restore database ' + @devel_db_name + ' from disk = ''D:\Scripts\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak''
+'restore database ' + @devel_db_name + ' from disk = ''D:\Proc_references\Devel_backups\Latest release\gtdb2_devel_backup.bak''
 with move ''GTDB2_devel_Data'' to ''D:\SQLUserDBData\' + @devel_db_name + '.MDF'',
 move ''GTDB2_devel_Log''to ''D:\SQLUserDBTransLogs\' + @devel_db_name + '.ldf'',
 replace, recovery

--- a/Administration_procedures/p_admin_CreateDevelUserSQL.sql
+++ b/Administration_procedures/p_admin_CreateDevelUserSQL.sql
@@ -12,13 +12,13 @@ GO
 -- Initial password is "molmed2015"
 --read only databases are listed in readonly_dbs.txt 
 --owner databases are listed in owner_dbs.txt in 
---directory: D:\Scripts\Anv?ndbara script\Skapa anv?ndare\Developers
+--directory: D:\Proc_references
 --Also, user is added in table authority in GTDB2 and BookKeeping devel dbs
 
 -- Parameters
 -- @login_name: Login name for sql-user (restricted permissions), the login and db -users will be created in this script
 -- @sys_admin_login_name: sysadmin login name, should already been created before the call to this procedure
--- @devel_db_name: Name of the 'personal' devel db, e.g. GTDB2_devel_<initials>
+-- @initials: The name of the 'personal' devel db is generated according to pattern GTDB2_devel_<initials>
 
 alter procedure p_admin_CreateDevelUserSQL(
 	@login_name varchar(255),
@@ -75,7 +75,7 @@ end
 -- Read databases to be mapped from files into temp tables
 --&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 create table #readonly(db varchar(255))
-bulk insert #readonly from 'D:\Scripts\Proc_references\Devel_user_dbs\readonly_dbs.txt'
+bulk insert #readonly from 'D:\Proc_references\Devel_user_dbs\readonly_dbs.txt'
 with 
 (
 	rowterminator = '\n'
@@ -90,7 +90,7 @@ insert into #readonly2
 select db, ROW_NUMBER() over (order by db desc) from #readonly
 
 create table #owner (db varchar(235))
-bulk insert #owner from 'D:\Scripts\Proc_references\Devel_user_dbs\owner_dbs.txt'
+bulk insert #owner from 'D:\Proc_references\Devel_user_dbs\owner_dbs.txt'
 with 
 (
 	rowterminator = '\n'
@@ -106,7 +106,7 @@ select db, ROW_NUMBER() over (order by db desc) from #owner
 -- op-databases = database that have another database with the same name ending with 'practice' or 'devel'
 --&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 create table #op_dbs (db varchar(235))
-bulk insert #op_dbs from 'D:\Scripts\Proc_references\Devel_user_dbs\operational_dbs.txt'
+bulk insert #op_dbs from 'D:\Proc_references\Devel_user_dbs\operational_dbs.txt'
 with 
 (
 	rowterminator = '\n'

--- a/Administration_procedures/p_admin_CreateDevelUserWindows.sql
+++ b/Administration_procedures/p_admin_CreateDevelUserWindows.sql
@@ -12,7 +12,7 @@ GO
 
 --Creates users for each database that is listed in file owner_dbs.txt for @login_name
 --@login_name should match a ordinary windows user, including the domain name USER\
---directory for file: D:\Scripts\Anv?ndbara script\Skapa anv?ndare\Developers
+--directory for file: D:\Proc_references
 --Also, user is added in table authority in GTDB2 and BookKeeping devel dbs
 
 
@@ -50,7 +50,7 @@ end
 -- Create temp tables
 --&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 create table #owner (db varchar(235))
-bulk insert #owner from 'D:\Scripts\Proc_references\Devel_user_dbs\owner_dbs.txt'
+bulk insert #owner from 'D:\Proc_references\Devel_user_dbs\owner_dbs.txt'
 with 
 (
 	rowterminator = '\n'

--- a/Auxilliary_procedures/p_IdPanelStrandCheck.sql
+++ b/Auxilliary_procedures/p_IdPanelStrandCheck.sql
@@ -17,7 +17,7 @@ create table #strandrefs (
 )
 
 
-bulk insert #strandrefs from 'D:\Scripts\Proc_references\gtdb2_id_panel_check\id_panel_strand_refs.txt' 
+bulk insert #strandrefs from 'D:\Proc_references\gtdb2_id_panel_check\id_panel_strand_refs.txt' 
 with (
 	fieldterminator = '\t',
 	rowterminator = '\n'


### PR DESCRIPTION
Paths for the referencing files (e.g. backup files) have moved from D:\Scripts\Proc_references to D:\Proc_references. 