### PR TITLE
dev-1032, fix personal db for Order

### DIFF
--- a/Administration_procedures/Administration_procedures.ssmssqlproj
+++ b/Administration_procedures/Administration_procedures.ssmssqlproj
@@ -15,6 +15,18 @@
           <ConnectionProtocol>NotSpecified</ConnectionProtocol>
           <ApplicationName>Microsoft SQL Server Management Studio - Query</ApplicationName>
         </ConnectionNode>
+        <ConnectionNode Name="MM-WCHS001:devel_edvard">
+          <Created>2019-01-07T12:37:49.447818+01:00</Created>
+          <Type>SQL</Type>
+          <Server>MM-WCHS001</Server>
+          <UserName>devel_edvard</UserName>
+          <Authentication>SQL</Authentication>
+          <InitialDB />
+          <LoginTimeout>15</LoginTimeout>
+          <ExecutionTimeout>0</ExecutionTimeout>
+          <ConnectionProtocol>NotSpecified</ConnectionProtocol>
+          <ApplicationName>Microsoft SQL Server Management Studio - Query</ApplicationName>
+        </ConnectionNode>
         <ConnectionNode Name="MM-WCHS001:USER\edeng655">
           <Created>2015-05-12T17:44:48.6031686+02:00</Created>
           <Type>SQL</Type>
@@ -67,16 +79,28 @@
           <AssociatedConnUserName />
           <FullPath>p_admin_GrantExecuteThis.sql</FullPath>
         </FileNode>
+        <FileNode Name="p_Backup_QC_DevelLatestMerge.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
+          <FullPath>p_Backup_QC_DevelLatestMerge.sql</FullPath>
+        </FileNode>
+        <FileNode Name="p_Backup_QC_DevelLatestRelease.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
+          <FullPath>p_Backup_QC_DevelLatestRelease.sql</FullPath>
+        </FileNode>
         <FileNode Name="p_BackupDevelLatestMerge.sql">
-          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:mm-wchs001:False:admin_edvard</AssociatedConnectionMoniker>
-          <AssociatedConnSrvName>mm-wchs001</AssociatedConnSrvName>
-          <AssociatedConnUserName>admin_edvard</AssociatedConnUserName>
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
           <FullPath>p_BackupDevelLatestMerge.sql</FullPath>
         </FileNode>
         <FileNode Name="p_BackupDevelLatestRelease.sql">
-          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:mm-wchs001:False:admin_edvard</AssociatedConnectionMoniker>
-          <AssociatedConnSrvName>mm-wchs001</AssociatedConnSrvName>
-          <AssociatedConnUserName>admin_edvard</AssociatedConnUserName>
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
           <FullPath>p_BackupDevelLatestRelease.sql</FullPath>
         </FileNode>
         <FileNode Name="p_CloneGTDB2DevelToPersonal.sql">
@@ -85,10 +109,16 @@
           <AssociatedConnUserName>admin_edvard</AssociatedConnUserName>
           <FullPath>p_CloneGTDB2DevelToPersonal.sql</FullPath>
         </FileNode>
+        <FileNode Name="p_Restore_QC_Devel.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
+          <FullPath>p_Restore_QC_Devel.sql</FullPath>
+        </FileNode>
         <FileNode Name="p_RestoreGTDB2Devel.sql">
-          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:mm-wchs001:False:admin_edvard</AssociatedConnectionMoniker>
-          <AssociatedConnSrvName>mm-wchs001</AssociatedConnSrvName>
-          <AssociatedConnUserName>admin_edvard</AssociatedConnUserName>
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
           <FullPath>p_RestoreGTDB2Devel.sql</FullPath>
         </FileNode>
         <FileNode Name="p_UpdateApplicationVersion.sql">

--- a/Administration_procedures/p_Backup_Order_DevelLatestMerge.sql
+++ b/Administration_procedures/p_Backup_Order_DevelLatestMerge.sql
@@ -1,0 +1,25 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_BackupDevelLatestMerge]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+alter procedure p_Backup_Order_DevelLatestMerge
+as
+begin
+SET NOCOUNT ON
+
+backup database BookKeeping_devel to disk = 'D:\Proc_references\Devel_backups\Latest merge\order_devel_backup.bak'
+with init, skip
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_Backup_Order_DevelLatestRelease.sql
+++ b/Administration_procedures/p_Backup_Order_DevelLatestRelease.sql
@@ -1,0 +1,25 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_BackupDevelLatestRelease]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+create procedure p_Backup_Order_DevelLatestRelease
+as
+begin
+SET NOCOUNT ON
+
+backup database BookKeeping_devel to disk = 'D:\Proc_references\Devel_backups\Latest release\order_devel_backup.bak'
+with init, skip
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_Backup_QC_DevelLatestMerge.sql
+++ b/Administration_procedures/p_Backup_QC_DevelLatestMerge.sql
@@ -1,0 +1,25 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_BackupDevelLatestMerge]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+create procedure p_Backup_QC_DevelLatestMerge
+as
+begin
+SET NOCOUNT ON
+
+backup database qc_devel to disk = 'D:\Proc_references\Devel_backups\Latest merge\qc_devel_backup.bak'
+with init, skip
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_Backup_QC_DevelLatestRelease.sql
+++ b/Administration_procedures/p_Backup_QC_DevelLatestRelease.sql
@@ -1,0 +1,25 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_BackupDevelLatestRelease]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+create procedure p_Backup_QC_DevelLatestRelease
+as
+begin
+SET NOCOUNT ON
+
+backup database qc_devel to disk = 'D:\Proc_references\Devel_backups\Latest release\qc_devel_backup.bak'
+with init, skip
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_Clone_Order_DevelToPersonal.sql
+++ b/Administration_procedures/p_Clone_Order_DevelToPersonal.sql
@@ -1,0 +1,122 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_CloneGTDB2DevelLatestRelease]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- Create a 'personal' devel database by cloning the common devel db backup in the release folder
+-- The database created will match the person calling this procedure
+-- who must exists in tables map_devel_table and map_devel_user in Administration
+-- Use procedure p_admin_CreateDevelUserSQL if current user is not present in above tables
+
+-- @version:	If the caller wants to have more than one devel databases. E.g. if @version = 2 and user
+--				initials is 'ee', then a devel database with name GTDB2_devel_ee2 will be created. If there
+--				is an existing database with name GTDB2_devel_ee, it will not be affected. 
+
+create procedure p_Clone_Order_DevelToPersonal @version int = null, @latest_release bit = 1, @latest_merge bit = 0
+
+as
+begin
+SET NOCOUNT ON
+
+declare @devel_db_name varchar(255)
+declare @sql varchar(max)
+declare @sqltable table(sql varchar(max))
+declare @counter int
+declare @backup_file varchar(1024)
+
+
+if @latest_merge = 1 begin
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest merge\order_devel_backup.bak'''
+end
+if @latest_release = 1 begin
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest release\order_devel_backup.bak'''
+end
+
+-- Find 'personal' devel db name for current user
+select @devel_db_name = devel_db_name from map_devel_table where login = SYSTEM_USER and operation_db_name = 'BookKeeping'
+
+if isnull(@devel_db_name, '###') = '###' begin
+	raiserror('Could not find devel db name for database BookKeeping (table map_devel_table in Administration)', 15,1)
+end
+
+if isnull(@version, -1) > -1 begin
+	set @devel_db_name = @devel_db_name + cast(@version as varchar(10))
+end
+
+-- Restore backup from latest release folder
+set @sql = 
+'if exists (select name from Administration.dbo.sysdatabases where name = ''' + @devel_db_name + ''') begin
+	alter database ' + @devel_db_name + ' set single_user with rollback immediate
+end
+'
+
+set @sql = @sql + 
+'restore database ' + @devel_db_name + ' from disk = '+ @backup_file + '
+with move ''BookKeeping_devel'' to ''D:\SQLUserDBData\' + @devel_db_name + '.MDF'',
+move ''BookKeeping_devel_log''to ''D:\SQLUserDBTransLogs\' + @devel_db_name + '.ldf'',
+replace, recovery
+
+alter database ' + @devel_db_name + ' set multi_user
+'
+
+exec (@sql)
+
+-- Remove all owner roles associated with sql users beginning with 'User_'
+set @sql = '
+declare @owners table(db_user varchar(255), rn int)
+declare @sql varchar(max)
+declare @counter int
+'
+
+if not exists( select * from map_devel_user where login = SYSTEM_USER) begin
+	raiserror('Could not find matching user in devel-db for current system user', 15,1)
+end
+
+
+select @sql = @sql + 
+'
+use ' + @devel_db_name + '
+insert into @owners
+(db_user, rn)
+select mp.name as database_user, ROW_NUMBER() over (order by mp.name)
+from sys.database_role_members drm
+  inner join sys.database_principals rp on (drm.role_principal_id = rp.principal_id)
+  inner join sys.database_principals mp on (drm.member_principal_id = mp.principal_id)
+where rp.name = ''db_owner'' and mp.name like ''User%'' and mp.type =  ''s'' 
+and not mp.name = ''' + devel_user + '''
+'
+from map_devel_user where login = system_user
+
+
+set @sql = @sql + 'use ' + @devel_db_name + '
+set @counter = 1
+set @sql = ''''
+while exists (select * from @owners where rn = @counter) begin
+	select @sql = @sql + ''
+	use ' + @devel_db_name + '
+	alter role db_owner drop member '' + db_user
+	from @owners where rn = @counter
+	set @counter = @counter + 1
+end
+select @sql
+'
+
+insert into @sqltable 
+(sql)
+exec (@sql)
+
+select @sql = sql from @sqltable
+
+exec (@sql)
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_Restore_Order_Devel.sql
+++ b/Administration_procedures/p_Restore_Order_Devel.sql
@@ -1,0 +1,61 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_CloneGTDB2DevelLatestRelease]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+-- Restore GTDB2_devel from backup. 
+-- Parameters:
+-- @latest_version			Restores from the latest release backup
+-- @latest_merge			Restores from the latest merge backup
+
+create procedure p_RestoreOrderDevel @latest_release bit = 1, @latest_merge bit = 0
+
+as
+begin
+SET NOCOUNT ON
+
+declare @devel_db_name varchar(255)
+declare @sql varchar(max)
+declare @backup_file varchar(1024)
+
+set @devel_db_name = 'BookKeeping_devel'
+
+if @latest_merge = 1 begin
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest merge\BookKeeping_devel_backup.bak'''
+end
+if @latest_release = 1 begin
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest release\BookKeeping_devel_backup.bak'''
+end
+
+-- Restore backup from latest release folder
+set @sql = 
+'if exists (select name from Administration.dbo.sysdatabases where name = ''' + @devel_db_name + ''') begin
+	alter database ' + @devel_db_name + ' set single_user with rollback immediate
+end
+'
+
+set @sql = @sql + 
+'restore database ' + @devel_db_name + ' from disk = '+ @backup_file + '
+with 
+replace, recovery
+
+alter database ' + @devel_db_name + ' set multi_user
+'
+
+--select @sql
+--return
+
+exec (@sql)
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_Restore_QC_Devel.sql
+++ b/Administration_procedures/p_Restore_QC_Devel.sql
@@ -1,0 +1,61 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_CloneGTDB2DevelLatestRelease]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+-- Restore GTDB2_devel from backup. 
+-- Parameters:
+-- @latest_version			Restores from the latest release backup
+-- @latest_merge			Restores from the latest merge backup
+
+create procedure p_Restore_QC_Devel @latest_release bit = 1, @latest_merge bit = 0
+
+as
+begin
+SET NOCOUNT ON
+
+declare @devel_db_name varchar(255)
+declare @sql varchar(max)
+declare @backup_file varchar(1024)
+
+set @devel_db_name = 'QC_devel'
+
+if @latest_merge = 1 begin
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest merge\qc_devel_backup.bak'''
+end
+if @latest_release = 1 begin
+	set @backup_file = '''D:\Proc_references\Devel_backups\Latest release\qc_devel_backup.bak'''
+end
+
+-- Restore backup from latest release folder
+set @sql = 
+'if exists (select name from Administration.dbo.sysdatabases where name = ''' + @devel_db_name + ''') begin
+	alter database ' + @devel_db_name + ' set single_user with rollback immediate
+end
+'
+
+set @sql = @sql + 
+'restore database ' + @devel_db_name + ' from disk = '+ @backup_file + '
+with 
+replace, recovery
+
+alter database ' + @devel_db_name + ' set multi_user
+'
+
+--select @sql
+--return
+
+exec (@sql)
+
+
+SET NOCOUNT off
+end
+go
+
+

--- a/Administration_procedures/p_admin_Clone_Order_DevelLatestRelease.sql
+++ b/Administration_procedures/p_admin_Clone_Order_DevelLatestRelease.sql
@@ -1,0 +1,183 @@
+use Administration
+GO
+
+/****** Object:  StoredProcedure [dbo].[p_admin_CloneGTDB2DevelLatestRelease]    Script Date: 2014-02-27 14:07:56 ******/
+SET ANSI_NULLS OFF
+GO
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- Create a 'personal' devel database by cloning the common devel db backup in the merge folder
+-- The database created will match the person calling this procedure
+-- who must exists in tables map_devel_table and map_devel_user in Administration
+-- Use procedure p_CreateDevelUserSQL if current user is not present in above tables
+
+create procedure p_admin_Clone_Order_DevelLatestRelease(
+	@devel_login varchar(255),
+	@devel_db_version_nr int = null
+)
+
+as
+begin
+SET NOCOUNT ON
+
+declare @devel_db_name varchar(255)
+declare @sql varchar(max)
+declare @sqltable table(sql varchar(max))
+declare @counter int
+declare @current_user varchar(20)
+declare @current_login varchar(30)
+
+-- Find 'personal' devel db name for current user
+select @devel_db_name = devel_db_name from map_devel_table where login = @devel_login and operation_db_name = 'BookKeeping'
+
+if isnull(@devel_db_name, '###') = '###' begin
+	raiserror('Could not find devel db name for database BookKeeping (table map_devel_table in Administration)', 15,1)
+end
+
+if isnull(@devel_db_version_nr, -1) > -1 begin
+	set @devel_db_name = @devel_db_name + cast( @devel_db_version_nr as varchar(10))
+end
+
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+-- Restore backup from latest release folder
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+set @sql = 
+'if exists (select name from Administration.dbo.sysdatabases where name = ''' + @devel_db_name + ''') begin
+	alter database ' + @devel_db_name + ' set single_user with rollback immediate
+end
+'
+
+set @sql = @sql + 
+'restore database ' + @devel_db_name + ' from disk = ''D:\Proc_references\Devel_backups\Latest release\order_devel_backup.bak''
+with move ''BookKeeping_devel'' to ''D:\SQLUserDBData\' + @devel_db_name + '.MDF'',
+move ''BookKeeping_devel_log''to ''D:\SQLUserDBTransLogs\' + @devel_db_name + '.ldf'',
+replace, recovery
+
+alter database ' + @devel_db_name + '  modify file (name = BookKeeping_devel, newname = ' + @devel_db_name + '_Data)
+alter database ' + @devel_db_name + ' modify file (name = BookKeeping_devel_log, newname = ' + @devel_db_name + '_Log)
+
+alter database ' + @devel_db_name + ' set multi_user
+'
+
+exec (@sql)
+
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+-- Remove all owner roles associated with sql users beginning with 'User_'
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+set @sql = '
+declare @owners table(db_user varchar(255), rn int)
+declare @sql varchar(max)
+declare @counter int
+'
+
+set @sql = @sql + 
+'
+use ' + @devel_db_name + '
+insert into @owners
+(db_user, rn)
+select mp.name as database_user, ROW_NUMBER() over (order by mp.name)
+from sys.database_role_members drm
+  inner join sys.database_principals rp on (drm.role_principal_id = rp.principal_id)
+  inner join sys.database_principals mp on (drm.member_principal_id = mp.principal_id)
+where rp.name = ''db_owner'' and mp.name like ''User%'' and mp.type =  ''s''
+'
+
+
+set @sql = @sql + 'use ' + @devel_db_name + '
+set @counter = 1
+set @sql = ''''
+while exists (select * from @owners where rn = @counter) begin
+	select @sql = @sql + ''
+	use ' + @devel_db_name + '
+	alter role db_owner drop member '' + db_user
+	from @owners where rn = @counter
+	set @counter = @counter + 1
+end
+select @sql
+'
+
+insert into @sqltable 
+(sql)
+exec (@sql)
+
+select @sql = sql from @sqltable
+
+exec (@sql)
+
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+-- Add current associated database user as db owner
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+
+if not exists( select * from map_devel_user where login = @devel_login) begin
+	raiserror('Could not find matching user in devel-db specified login, %s', 15,1, @devel_login)
+end
+
+select @sql = '
+declare @sql2 varchar(max)
+set @sql2 = ''
+use ' + @devel_db_name + '''
+if not exists(select name from ' + @devel_db_name + '.sys.database_principals where type = ''s'' and name = ''' + devel_user + ''') begin
+	set @sql2 = @sql2 + ''
+	create user ' + devel_user + ' for login ' + @devel_login + '
+	''
+end
+else begin
+	set @sql2 = @sql2 + ''
+	alter user ' + devel_user + ' with login = ' + @devel_login + '
+	''
+end
+set @sql2 = @sql2 + ''
+alter role db_owner add member ' + devel_user + '
+grant alter any role to ' + devel_user + '''
+select @sql2'
+from map_devel_user where login = @devel_login
+
+delete from @sqltable
+insert into @sqltable
+(sql)
+exec (@sql)
+
+select @sql = sql from @sqltable
+
+exec (@sql)
+
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+-- Add all members in map_table_user as datareaders
+--&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+set @sql = ''
+declare cur cursor local for
+select login, devel_user from Administration.dbo.map_devel_user mdu
+inner join master.sys.server_principals sp on mdu.login = sp.name
+where sp.type = 's'
+
+open cur
+
+fetch next from cur into @current_login, @current_user
+
+while @@FETCH_STATUS = 0 begin
+	set @sql = @sql + '
+	use ' + @devel_db_name + '
+	if not exists(select name from ' + @devel_db_name + '.sys.database_principals where type = ''s'' and name = ''' + @current_user + ''') begin
+		create user ' + @current_user + ' for login [' + @current_login + ']
+	end
+	alter role db_datareader add member ' + @current_user + '
+	'
+	fetch next from cur into @current_login, @current_user
+end
+
+close cur
+
+deallocate cur
+
+exec (@sql)
+
+
+
+SET NOCOUNT off
+end
+go
+
+
+


### PR DESCRIPTION
Purpose:
Provide for a personal dev db for each developer, e.g. BookKeeping_devel_ee, together with a set of database procedures that performs backup-restore procedures. This database can be cloned from the parent database BookKeeping_devel, or when needed at releases, the parent database can be cloned by a child database. 

